### PR TITLE
Fix assertion that the arguments to long-reset were numbers

### DIFF
--- a/bbbrtc.c
+++ b/bbbrtc.c
@@ -632,8 +632,10 @@ int cmd_long_reset( const char *down_time, const char *delay ) {
 
   if ( down_time ) {
     int_down_time = (unsigned) strtoul( down_time , &notn , 10 );
-    diagprint("\nERROR: Down time must be a number.\n");
-    return 1;
+    if ( notn == down_time ){
+      diagprint("\nERROR: Down time must be a number.\n");
+      return 1;
+    }
   } else {
     diagprint("\nERROR: Missing required argument \"down_time\".\n");
     return 1;
@@ -641,8 +643,10 @@ int cmd_long_reset( const char *down_time, const char *delay ) {
 
   if ( delay ) {
     int_delay = (unsigned) strtoul( delay , &notn , 10 );
-    diagprint("\nERROR: Delay must be a number.\n");
-    return 1;
+    if ( notn == delay ){
+      diagprint("\nERROR: Delay must be a number.\n");
+      return 1;
+    }
   } else {
     diagprint("\nERROR: Missing required argument \"delay\".\n");
     return 1;

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 all: bbbrtc install
 
 bbbrtc: bbbrtc.c
-	g++ bbbrtc.c -o bbbrtc
+	$(CXX) bbbrtc.c -o bbbrtc
 	chmod +x bbbrtc
 
 .PHONY: install
@@ -10,3 +10,7 @@ install: bbbrtc
 	mkdir -p $(DESTDIR)/usr/sbin
 	sudo install bbbrtc $(DESTDIR)/usr/sbin/
 	sudo install bbb-long-reset $(DESTDIR)/usr/sbin/
+
+.PHONY: clean
+clean:
+	rm -f bbbrtc


### PR DESCRIPTION
I somehow dropped my if statements in a previous commit. This will make the long-reset command work as intended.