### PR TITLE
Use sh instead of bash in bbb-long-reset

### DIFF
--- a/bbb-long-reset
+++ b/bbb-long-reset
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 # tell power controller to accept signals
 i2cset -f -y 0 0x24 0x0a 0x00
 
 # unlock rtc registers if we are running a kernel newer than 3.X
-kernel_major=`uname -r | grep -o -E '^[0-9]+'`
+kernel_major=$(uname -r | grep -o -E '^[0-9]+')
 if [ "$kernel_major" -ge "4" ]; then
   bbbrtc unlock
 fi


### PR DESCRIPTION
For the same reason that on https://github.com/bigjosh/bbbphyfix/pull/3, use `sh` instead of `bash` in order to use it on a Buildroot minimal system.

Note that I have changed the `kernel_major` assignation after a check on <https://www.shellcheck.net/>